### PR TITLE
Add xdg as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@ setup(
     author="Daniel Mach",
     author_email="dmach@redhat.com",
     license="MIT",
+    install_requires=[
+        "pyxdg"
+    ],
     packages=find_packages(),
     include_package_data=True,
     scripts=[


### PR DESCRIPTION
pyxdg was missing as a dependency, adding install_requires in setup.py