### PR TITLE
Setup tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,13 @@
+[tox]
+envlist = py26,py27,py33,py34,py35
+
+[testenv]
+deps =
+    pytest
+
+commands =
+    py.test
+
 [flake8]
 # E501: line too long
 # D200: One-line docstring should fit on one line with quotes

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,4 @@
+[flake8]
+# E501: line too long
+# D200: One-line docstring should fit on one line with quotes
+ignore = E501,D200


### PR DESCRIPTION
Using `py.test` for test discovery. If this is not a desired dependency, could be changed to `unittest discover`.