### PR TITLE
Remove hidden defult from Environment class

### DIFF
--- a/releng_sop/common.py
+++ b/releng_sop/common.py
@@ -69,11 +69,6 @@ class Environment(ConfigBase):
     config_subdir = "environments"
     default_config = "default"
 
-    def __init__(self, name=None, config_dirs=None):
-        # make 'name' argument optional, use 'default' environment by default
-        name = name or "default"
-        super(Environment, self).__init__(name, config_dirs)
-
 
 class Release(ConfigBase):
     config_subdir = "releases"

--- a/releng_sop/koji_block_package_in_release.py
+++ b/releng_sop/koji_block_package_in_release.py
@@ -40,7 +40,10 @@ class KojiBlockPackageInRelease(KojiBase):
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(description="Block packages in a koji tag that maps to given release.")
+    parser = argparse.ArgumentParser(
+        description="Block packages in a koji tag that maps to given release.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "release_id",
         metavar="RELEASE_ID",
@@ -59,6 +62,7 @@ def get_parser():
     )
     parser.add_argument(
         "--env",
+        default="default",
         help="Select environment in which the program will make changes.",
     )
     return parser

--- a/releng_sop/koji_create_package_in_release.py
+++ b/releng_sop/koji_create_package_in_release.py
@@ -45,7 +45,10 @@ class KojiCreatePackageInRelease(KojiBase):
 
 
 def get_parser():
-    parser = argparse.ArgumentParser(description="Create packages in a koji tag that maps to given release.")
+    parser = argparse.ArgumentParser(
+        description="Block packages in a koji tag that maps to given release.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "release_id",
         metavar="RELEASE_ID",
@@ -65,10 +68,12 @@ def get_parser():
     parser.add_argument(
         "--owner",
         required=True,
+        default=argparse.SUPPRESS,
         help="Package owner",
     )
     parser.add_argument(
         "--env",
+        default="default",
         help="Select environment in which the program will make changes.",
     )
     return parser


### PR DESCRIPTION
There is no point in having an Environment object without a name;
users of the Environment class should set defaults, if they want.
Default for the '--env' option is set in argparse now.

Using formatter_class=argparse.ArgumentDefaultsHelpFormatter, to have
the default values displayed in help.