### PR TITLE
Enable tox checks before commits

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+#
+# To enable this hook, do from your repo root:
+#       pushd .git/hooks
+#       ln -s -f ../../hooks/pre-commit.sh pre-commit
+#       popd
+#
+
+TOX="tox"
+# Don't care about missing interpreters,
+# those will be checked by travis anyways.
+TOXOPT="--skip-missing-interpreters"
+
+MSG="Please install $TOX to check your work before commiting. Aborting."
+
+# First let's check that tox is available...
+command -v $TOX >/dev/null 2>&1 || { echo >&2 $MSG; exit 1; }
+
+$TOX $TOXOPT

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,py35,flake8
+envlist = py26,py27,py33,py34,py35,flake8,docs
 
 [testenv]
 deps =


### PR DESCRIPTION
* Set up sphinx to treat all warnings as errors.

* Add docs environment to the list of environments, so that
  tox calls sphinx, and fails if there are errors/warnings.

* Create script for pre-commit hook, which checks if tox is
  available, and calls tox before each commit.