### PR TITLE
Remove traces from error messages

### DIFF
--- a/releng_sop/common.py
+++ b/releng_sop/common.py
@@ -13,7 +13,21 @@ __all__ = (
     "Environment",
     "Release",
     "get_logger",
+    "Error",
+    "ConfigError",
 )
+
+
+class Error(Exception):
+    """Base class for releng-sop errors."""
+
+    pass
+
+
+class ConfigError(Error):
+    """Error to be raised for configuration errors."""
+
+    pass
 
 
 class ConfigBase(object):
@@ -52,7 +66,9 @@ class ConfigBase(object):
             if os.path.exists(path):
                 self.config_path = path
                 return
-        raise RuntimeError("Couldn't find config file '%s' in following locations:\n%s" % (filename, "\n".join(self.config_dirs)))
+
+        message = "Couldn't find config file '%s' in following locations:\n%s"
+        raise ConfigError(message % (filename, "\n".join(self.config_dirs)))
 
     def _read_config(self):
         """

--- a/releng_sop/koji_block_package_in_release.py
+++ b/releng_sop/koji_block_package_in_release.py
@@ -130,10 +130,10 @@ def main():
         clone = KojiBlockPackageInRelease(env, release, args.packages)
         clone.run(commit=args.commit)
 
-    except Error as e:
+    except Error:
         if not args.debug:
             sys.tracebacklimit = 0
-        raise e
+        raise
 
 
 if __name__ == "__main__":

--- a/releng_sop/koji_block_package_in_release.py
+++ b/releng_sop/koji_block_package_in_release.py
@@ -14,10 +14,11 @@ RELEASE_TAG is the "tag_release" key from the release configuration
 
 from __future__ import print_function
 from __future__ import unicode_literals
+import sys
 
 import argparse
 
-from .common import Environment, Release
+from .common import Environment, Release, Error
 from .kojibase import KojiBase
 
 
@@ -110,17 +111,29 @@ def get_parser():
         default="default",
         help="Select environment in which the program will make changes.",
     )
+    parser.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="Print traceback for exceptions. By default only exception messages are displayed.",
+    )
     return parser
 
 
 def main():
     """Main function."""
-    parser = get_parser()
-    args = parser.parse_args()
-    env = Environment(args.env)
-    release = Release(args.release_id)
-    clone = KojiBlockPackageInRelease(env, release, args.packages)
-    clone.run(commit=args.commit)
+    try:
+        parser = get_parser()
+        args = parser.parse_args()
+
+        env = Environment(args.env)
+        release = Release(args.release_id)
+        clone = KojiBlockPackageInRelease(env, release, args.packages)
+        clone.run(commit=args.commit)
+
+    except Error as e:
+        if not args.debug:
+            sys.tracebacklimit = 0
+        raise e
 
 
 if __name__ == "__main__":

--- a/releng_sop/koji_clone_tag_for_release_milestone.py
+++ b/releng_sop/koji_clone_tag_for_release_milestone.py
@@ -153,10 +153,10 @@ def main():
         clone = KojiCloneTagForReleaseMilestone(env, release, args.milestone)
         clone.run(commit=args.commit)
 
-    except Error as e:
+    except Error:
         if not args.debug:
             sys.tracebacklimit = 0
-        raise e
+        raise
 
 if __name__ == "__main__":
     main()

--- a/releng_sop/koji_clone_tag_for_release_milestone.py
+++ b/releng_sop/koji_clone_tag_for_release_milestone.py
@@ -17,11 +17,14 @@ milestone_tag is main release tag + name of milestone + milestone major version 
 
 
 from __future__ import print_function
+from __future__ import unicode_literals
+import sys
 
 import argparse
+
 from productmd.composeinfo import verify_label as verify_milestone
 
-from .common import Environment, Release
+from .common import Environment, Release, Error
 from .kojibase import KojiBase
 
 
@@ -107,7 +110,10 @@ def get_parser():
     :returns: ArgumentParser object with arguments set up.
     :rtype: argparse.ArgumentParser
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        description="Clone tag for release milestone.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     parser.add_argument(
         "release_id",
         metavar="RELEASE_ID",
@@ -128,18 +134,29 @@ def get_parser():
         default="default",
         help="Select environment in which the program will make changes.",
     )
+    parser.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="Print traceback for exceptions. By default only exception messages are displayed.",
+    )
     return parser
 
 
 def main():
     """Main function."""
-    parser = get_parser()
-    args = parser.parse_args()
-    env = Environment(args.env)
-    release = Release(args.release_id)
-    clone = KojiCloneTagForReleaseMilestone(env, release, args.milestone)
-    clone.run(commit=args.commit)
+    try:
+        parser = get_parser()
+        args = parser.parse_args()
 
+        env = Environment(args.env)
+        release = Release(args.release_id)
+        clone = KojiCloneTagForReleaseMilestone(env, release, args.milestone)
+        clone.run(commit=args.commit)
+
+    except Error as e:
+        if not args.debug:
+            sys.tracebacklimit = 0
+        raise e
 
 if __name__ == "__main__":
     main()

--- a/releng_sop/koji_create_package_in_release.py
+++ b/releng_sop/koji_create_package_in_release.py
@@ -142,10 +142,10 @@ def main():
         clone = KojiCreatePackageInRelease(env, release, args.packages, args.owner)
         clone.run(commit=args.commit)
 
-    except Error as e:
+    except Error:
         if not args.debug:
             sys.tracebacklimit = 0
-        raise e
+        raise
 
 if __name__ == "__main__":
     main()

--- a/releng_sop/koji_create_package_in_release.py
+++ b/releng_sop/koji_create_package_in_release.py
@@ -13,10 +13,11 @@ RELEASE_TAG is the "tag_release" key from the release configuration
 
 from __future__ import print_function
 from __future__ import unicode_literals
+import sys
 
 import argparse
 
-from .common import Environment, Release
+from .common import Environment, Release, Error
 from .kojibase import KojiBase
 
 
@@ -92,7 +93,7 @@ def get_parser():
     :returns: ArgumentParser object with arguments set up.
     """
     parser = argparse.ArgumentParser(
-        description="Block packages in a koji tag that maps to given release.",
+        description="Create packages in a koji tag that maps to given release.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -122,18 +123,29 @@ def get_parser():
         default="default",
         help="Select environment in which the program will make changes.",
     )
+    parser.add_argument(
+        "-d", "--debug",
+        action="store_true",
+        help="Print traceback for exceptions. By default only exception messages are displayed.",
+    )
     return parser
 
 
 def main():
     """Main function."""
-    parser = get_parser()
-    args = parser.parse_args()
-    env = Environment(args.env)
-    release = Release(args.release_id)
-    clone = KojiCreatePackageInRelease(env, release, args.packages, args.owner)
-    clone.run(commit=args.commit)
+    try:
+        parser = get_parser()
+        args = parser.parse_args()
 
+        env = Environment(args.env)
+        release = Release(args.release_id)
+        clone = KojiCreatePackageInRelease(env, release, args.packages, args.owner)
+        clone.run(commit=args.commit)
+
+    except Error as e:
+        if not args.debug:
+            sys.tracebacklimit = 0
+        raise e
 
 if __name__ == "__main__":
     main()

--- a/tests/test_release_data.py
+++ b/tests/test_release_data.py
@@ -12,7 +12,7 @@ import sys
 DIR = os.path.dirname(__file__)
 sys.path.insert(0, os.path.join(DIR, ".."))
 
-from releng_sop.common import Environment, Release  # noqa: E402
+from releng_sop.common import Environment, Release, ConfigError  # noqa: E402
 
 
 RELEASES_DIR = os.path.join(DIR, "releases")
@@ -114,14 +114,14 @@ class TestConfigDataNotFound(unittest.TestCase):
         """Raise RuntimeError when release data no found."""
         release_id = "no-such-release"
 
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ConfigError,
                           Release, release_id, config_dirs=[RELEASES_DIR])
 
     def test_environment_not_found(self):
         """Raise RuntimeError when environment configuration no found."""
         env_id = "no-such-environment"
 
-        self.assertRaises(RuntimeError,
+        self.assertRaises(ConfigError,
                           Environment, env_id, config_dirs=[ENVIRONMENTS_DIR])
 
 


### PR DESCRIPTION
In order to make error messages more user friendly, traceback limit is set to 0 by default.
Optional argument `-t, --traceback` re-enables tracebacks.