### PR TITLE
Fix for a paranoid check: D402

### DIFF
--- a/tests/test_common_pulp.py
+++ b/tests/test_common_pulp.py
@@ -26,7 +26,7 @@ mod = mock_module("pulp.client.admin.config")
 
 def read_config(paths, *args, **kwargs):
     """
-    Mock function for pulp.client.admin.config.read_config().
+    Mock function to be injected into pulp.client.admin.config.
     """
     cp = six.moves.configparser.RawConfigParser()
     cp.read(paths[0])


### PR DESCRIPTION
D402 First line should not be the function's 'signature'
