### PR TITLE
Mock all external dependencies for doc gen

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,18 +20,30 @@
 import os
 import sys
 import sphinx_rtd_theme
-
-# HACK: inject empty koji module to silence failing docs generation.
-# HACK: inject empty pulp.client.admin.config module to silence failing docs generation.
-# We need to add koji to deps (currently not possible)
-import imp
-sys.modules["koji"] = imp.new_module("koji")
-sys.modules["pulp"] = imp.new_module("pulp")
-sys.modules["pulp.client"] = imp.new_module("pulp.client")
-sys.modules["pulp.client.admin"] = imp.new_module("pulp.client.admin")
-sys.modules["pulp.client.admin.config"] = imp.new_module("pulp.client.admin.config")
+from mock import Mock as MagicMock
 
 sys.path.insert(0, os.path.abspath('..'))
+
+# -- Mock external dependencies ------------------------------------------
+
+# Don't want documentation for them, and not all of them will be available
+# through pip.
+
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+            return Mock()
+
+MOCK_MODULES = [
+    'koji',
+    'pdc_client',
+    'productmd', 'productmd.composeinfo',
+    'pulp', 'pulp.client', 'pulp.client.admin', 'pulp.client.admin.config',
+    'xdg', 'xdg.BaseDirectory',
+]
+
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -32,6 +32,10 @@ Dependencies for *tests* are duplicated in ``tox.ini`` and ``setup.py``
 ``tests_require`` section. This is done to support both ``setup.py test``
 and running the tests within tox, using pytest.
 
+When generating *documentation* external dependencies are mocked in
+``docs/conf.py``, in order to avoid breaking *readthedocs.org*
+due to missing environment dependencies.
+
 Once you have tox, you can run the tests like
 
 ::

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ deps =
 commands =
     py.test {posargs}
 
+whitelist_externals =
+    /usr/bin/make
+    make
+
 [testenv:flake8]
 basepython = python
 deps =
@@ -24,7 +28,9 @@ commands =
 [testenv:docs]
 basepython = python
 changedir = docs
+skip_install = True
 deps =
+    mock
     sphinx
     sphinx-argparse
     sphinx_rtd_theme


### PR DESCRIPTION
ReadTheDocs had issues with installing dependencies which
required additional C headers present in the environment.

As there is no need for external dependencies to be present
while generating documentation, all external dependencies are
mocked, so that they stand Sphinx's import.

Additionally, the package is not installed in the environment
to be used for generating documentation, in order to be consisent
with the settings on ReadTheDocs.