### PR TITLE
Update installation guide

### DIFF
--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -56,6 +56,13 @@ For generating documentation:
 
     $ tox -e docs
 
+tox will cache the environments in order to speed up test execution.
+Sometimes this can cause issues (when dependencies are changed or added).
+These can be overcome by recreating the tox environments using the ``-r`` flag.
+::
+
+    $ tox -r
+
 
 Pre-commit hook
 ---------------

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,11 +4,18 @@ Quickstart
 Installation
 ------------
 
+#. Install dependencies not available in PyPI:
+
+    ::
+
+        dnf install redhat-rpm-config python-devel krb5-devel pulp-admin-client
+
+
 #. Clone the git repo, and change to the repo directory:
 
     ::
 
-        git clone git@github.com:release-engineering/releng-sop.git
+        git clone https://github.com/release-engineering/releng-sop.git
         cd releng-sop
 
 
@@ -16,7 +23,7 @@ Installation
 
     ::
 
-        python<version> setup.py install
+        pip<version> install ./
 
 
 Configure environments

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,6 @@ whitelist_externals =
 basepython = python
 deps =
     flake8
-    pydocstyle==1.0.0
     flake8-docstrings
 commands =
     flake8


### PR DESCRIPTION
- Installation on a clean Fedora was missing some dependencies, these are included in the installation guide now.
- Issue with flake8-docstrings was fixed and released, so pinning down the version for pydocstyle is not required anymore.
- Updated contribution guide to mention tox option to recreate environments.